### PR TITLE
Revert "Do not require a less specific type than what is really needed"

### DIFF
--- a/main/src/cgeo/geocaching/apps/cache/navi/NavigationSelectionActionProvider.java
+++ b/main/src/cgeo/geocaching/apps/cache/navi/NavigationSelectionActionProvider.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.apps.cache.navi.NavigationAppFactory.NavigationAppsEnum;
 import cgeo.geocaching.ui.AbstractMenuActionProvider;
 
 import android.app.Activity;
+import android.content.Context;
 import android.support.v4.view.ActionProvider;
 import android.support.v4.view.MenuItemCompat;
 import android.view.Menu;
@@ -20,9 +21,9 @@ public class NavigationSelectionActionProvider extends AbstractMenuActionProvide
     private Geocache geocache;
     private final Activity activity;
 
-    public NavigationSelectionActionProvider(final Activity activity) {
-        super(activity);
-        this.activity = activity;
+    public NavigationSelectionActionProvider(final Context context) {
+        super(context);
+        activity = (Activity) context;
     }
 
     public void setTarget(final Geocache cache) {

--- a/main/src/cgeo/geocaching/loaders/GeokretyInventoryLoader.java
+++ b/main/src/cgeo/geocaching/loaders/GeokretyInventoryLoader.java
@@ -3,6 +3,7 @@ package cgeo.geocaching.loaders;
 import cgeo.geocaching.Trackable;
 import cgeo.geocaching.TrackableLog;
 import cgeo.geocaching.connector.trackable.GeokretyConnector;
+import cgeo.geocaching.connector.trackable.TrackableConnector;
 import cgeo.geocaching.utils.Log;
 
 import android.content.Context;
@@ -14,9 +15,9 @@ public class GeokretyInventoryLoader extends AbstractInventoryLoader {
     private final GeokretyConnector connector;
     private final List<TrackableLog> trackables = new ArrayList<>();
 
-    public GeokretyInventoryLoader(final Context context, final GeokretyConnector connector) {
+    public GeokretyInventoryLoader(final Context context, final TrackableConnector connector) {
         super(context);
-        this.connector = connector;
+        this.connector = (GeokretyConnector) connector;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/AbstractCheckCredentialsPreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractCheckCredentialsPreference.java
@@ -16,6 +16,7 @@ import rx.functions.Action1;
 import rx.functions.Func0;
 
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.preference.Preference;
@@ -23,12 +24,12 @@ import android.util.AttributeSet;
 
 public abstract class AbstractCheckCredentialsPreference extends AbstractClickablePreference {
 
-    public AbstractCheckCredentialsPreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
+    public AbstractCheckCredentialsPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    public AbstractCheckCredentialsPreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
+    public AbstractCheckCredentialsPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
     }
 
     @Override
@@ -51,7 +52,7 @@ public abstract class AbstractCheckCredentialsPreference extends AbstractClickab
         final private SettingsActivity settingsActivity;
 
         LoginCheckClickListener(final SettingsActivity activity) {
-            settingsActivity = activity;
+            this.settingsActivity = activity;
         }
 
         @Override

--- a/main/src/cgeo/geocaching/settings/AbstractClickablePreference.java
+++ b/main/src/cgeo/geocaching/settings/AbstractClickablePreference.java
@@ -1,5 +1,6 @@
 package cgeo.geocaching.settings;
 
+import android.content.Context;
 import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
@@ -9,14 +10,14 @@ abstract class AbstractClickablePreference extends Preference {
 
     final SettingsActivity activity;
 
-    public AbstractClickablePreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
-        this.activity = activity;
+    public AbstractClickablePreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+        activity = (SettingsActivity) context;
     }
 
-    public AbstractClickablePreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
-        this.activity = activity;
+    public AbstractClickablePreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        activity = (SettingsActivity) context;
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/CheckECCredentialsPreference.java
+++ b/main/src/cgeo/geocaching/settings/CheckECCredentialsPreference.java
@@ -8,17 +8,18 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import rx.Observable;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 
 public class CheckECCredentialsPreference extends AbstractCheckCredentialsPreference {
 
-    public CheckECCredentialsPreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
+    public CheckECCredentialsPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    public CheckECCredentialsPreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
+    public CheckECCredentialsPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/CheckGcCredentialsPreference.java
+++ b/main/src/cgeo/geocaching/settings/CheckGcCredentialsPreference.java
@@ -7,17 +7,18 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import rx.Observable;
 
+import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 
 public class CheckGcCredentialsPreference extends AbstractCheckCredentialsPreference {
 
-    public CheckGcCredentialsPreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
+    public CheckGcCredentialsPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    public CheckGcCredentialsPreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
+    public CheckGcCredentialsPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/OAuthPreference.java
+++ b/main/src/cgeo/geocaching/settings/OAuthPreference.java
@@ -7,6 +7,7 @@ import cgeo.geocaching.connector.oc.OCAuthParams;
 import cgeo.geocaching.connector.oc.OCAuthorizationActivity;
 import cgeo.geocaching.twitter.TwitterAuthorizationActivity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.preference.Preference;
 import android.util.AttributeSet;
@@ -48,14 +49,14 @@ public class OAuthPreference extends AbstractClickablePreference {
         return OAuthActivityMapping.NONE;
     }
 
-    public OAuthPreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
-        oAuthMapping = getAuthorization();
+    public OAuthPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+        this.oAuthMapping = getAuthorization();
     }
 
-    public OAuthPreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
-        oAuthMapping = getAuthorization();
+    public OAuthPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        this.oAuthMapping = getAuthorization();
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/RegisterSend2CgeoPreference.java
+++ b/main/src/cgeo/geocaching/settings/RegisterSend2CgeoPreference.java
@@ -18,17 +18,18 @@ import rx.functions.Action1;
 import rx.functions.Func0;
 
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.preference.Preference;
 import android.util.AttributeSet;
 
 public class RegisterSend2CgeoPreference extends AbstractClickablePreference {
 
-    public RegisterSend2CgeoPreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
+    public RegisterSend2CgeoPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    public RegisterSend2CgeoPreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
+    public RegisterSend2CgeoPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
     }
 
     @Override

--- a/main/src/cgeo/geocaching/settings/TokenPreference.java
+++ b/main/src/cgeo/geocaching/settings/TokenPreference.java
@@ -5,6 +5,7 @@ import cgeo.geocaching.R;
 import cgeo.geocaching.activity.TokenAuthorizationActivity.TokenAuthParameters;
 import cgeo.geocaching.connector.trackable.GeokretyAuthorizationActivity;
 
+import android.content.Context;
 import android.content.Intent;
 import android.preference.Preference;
 import android.util.AttributeSet;
@@ -40,14 +41,14 @@ public class TokenPreference extends AbstractClickablePreference {
         return TokenActivityMapping.NONE;
     }
 
-    public TokenPreference(final SettingsActivity activity, final AttributeSet attrs) {
-        super(activity, attrs);
-        tokenMapping = getAuthorization();
+    public TokenPreference(final Context context, final AttributeSet attrs) {
+        super(context, attrs);
+        this.tokenMapping = getAuthorization();
     }
 
-    public TokenPreference(final SettingsActivity activity, final AttributeSet attrs, final int defStyle) {
-        super(activity, attrs, defStyle);
-        tokenMapping = getAuthorization();
+    public TokenPreference(final Context context, final AttributeSet attrs, final int defStyle) {
+        super(context, attrs, defStyle);
+        this.tokenMapping = getAuthorization();
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 4cdb76d84ea3c639a7fe241ccd9c18fae1e7ba96 as it
causes problems during XML inflation.

> android.view.InflateException: Binary XML file line #44:
> Error inflating class cgeo.geocaching.settings.CheckGcCredentialsPreference